### PR TITLE
Führt Remember me ein

### DIFF
--- a/database/studienfuehrer.sql
+++ b/database/studienfuehrer.sql
@@ -297,6 +297,26 @@ INSERT INTO `ratings` (`ID`, `subject_ID`, `crit1`, `crit2`, `crit3`, `crit4`, `
 -- --------------------------------------------------------
 
 --
+-- Tabellenstruktur für Tabelle `remember_me`
+--
+
+CREATE TABLE `remember_me` (
+  `id` int(10) NOT NULL,
+  `user_id` int(10) NOT NULL,
+  `series` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `token` varchar(100) COLLATE utf8_unicode_ci NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- Daten für Tabelle `remember_me`
+--
+
+INSERT INTO `remember_me` (`id`, `user_id`, `series`, `token`) VALUES
+(1, 2, '43c727ee4fc7250574d2ef90cfa16626388a10e1b30d36ece1c272953ad2ed9e', '70d432707ec2478670d5b36a95d5b1000cb9c3ef6ea1fb7be14b060775723d03');
+
+-- --------------------------------------------------------
+
+--
 -- Tabellenstruktur für Tabelle `subjects`
 --
 

--- a/landing.php
+++ b/landing.php
@@ -71,6 +71,20 @@ if ($m == "no_admin"){
 	";
 }
 
+if ($m == "cookie_error"){
+	$msg = "Bei deinem automatischen Login ist ein Fehler aufgetreten. Lösche deine Cookies über das Browser-Menü und versuche erneut, dich einzuloggen. Solltest du weiterhin Probleme haben, wende dich direkt an die VWI-ESTIEM Hochschulgruppe.";
+}
+
+if ($m == "cookie_theft"){
+	$msg = "Du bist entweder Opfer eines Cookie-Räubers geworden und hast selbst nicht an dich halten können. Wir haben alle mit diesem Nutzer verbundenen Auto-Login-Daten gelöscht, sodass eine erneute Anmeldung erforderlich ist (Krümelmonster: Der Cookie ist wertlos!). Solltest du Fragen haben, wende dich direkt an die VWI-ESTIEM Hochschulgruppe.";
+}
+
+if ($m == "cookie_theft_error"){
+	$msg = "Du bist entweder Opfer eines Cookie-Räubers geworden und hast selbst nicht an dich halten können. Leider ist beim Löschen der mit diesem Nutzer verbundenen Auto-Login-Daten ein Fehler aufgetreten. Lösche deine Cookies über das Browser-Menü und melde dich erneut mit der Eingeloggt-bleiben-Funktion beim Studienführer an, um deine Daten zu überschreiben (Krümelmonster: Der Cookie ist dennoch wertlos!). Solltest du Fragen haben, wende dich direkt an die VWI-ESTIEM Hochschulgruppe.";
+}
+
+
+
 ?>
 <body>
 

--- a/login.php
+++ b/login.php
@@ -22,9 +22,8 @@ function setCookie(svalue,tvalue,uvalue,exdays) {
 	$.ajax({
 		url: "setCookieInDB.php",
 		type: "post",
-		data: {series: svalue, token: tvalue, user_id: uvalue} ,
-		success: function (data) {
-			alert(data);
+		data: {series: svalue, token: tvalue, user_id: uvalue},
+		success: function (data){
 		},
 		error: function() {
 			alert("error");
@@ -133,9 +132,7 @@ if (isset($_POST['btn-login'])) {
 			$_SESSION['userSession'] = $row['user_ID'];
 			
 			//Set cookie if remember me checked
-			echo "elseschleife<br>";
 			if(isset($_POST['rememberMe'])){
-				echo "checkbox on";
 				$series = hash("sha256", (rand(0,1000)));
 				$token = hash("sha256", (rand(0,1000)));
 				
@@ -156,7 +153,7 @@ if (isset($_POST['btn-login'])) {
 				<?php
 			}
 			
-			//echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
+			echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
 			
 			?>
 			<?php

--- a/login.php
+++ b/login.php
@@ -10,10 +10,6 @@ require_once 'connect.php';
 ?>
 
 <script>
-function deleteCookie(){
-	document.cookie = "vwistudi_series=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-}
-
 function setCookie(svalue,tvalue,uvalue,exdays) {
 	var d = new Date();
 	d.setTime(d.getTime() + (exdays*24*60*60*1000));
@@ -52,22 +48,14 @@ function getCookie(cname) {
     return "";
 }
 
-function checkCookie() {
-    var series=getCookie("vwistudi_series");
-	var token=getCookie("vwistudi_token");
-    if (series != "") {
-        alert("Saved series is: " + series + "Saved token is: " + token);
-    } else {
-       alert ("no cookie");
-    }
-}
 </script>
 
 <?php
+//Weiterleiten, falls bereits eingeloggt
 if (isset($_SESSION['userSession'])!="") {
-	//header('Location: tree.php');
 	echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
 	exit;
+//Checken, ob valider Cookie existiert und ggfls. einloggen
 }else{
 	if(isset($_COOKIE["vwistudi_series"]) && isset($_COOKIE["vwistudi_token"]) && isset($_COOKIE["vwistudi_user"])){
 		$cSeries = $_COOKIE["vwistudi_series"];
@@ -76,14 +64,22 @@ if (isset($_SESSION['userSession'])!="") {
 		
 		$result = mysqli_query($con, "SELECT * FROM remember_me WHERE series = '$cSeries' AND token = '$cToken' AND user_id = '$cUser'");
 		if(mysqli_num_rows($result) == 1){
-			echo "LOGIN!";
+			//echo "LOGIN!";
+			$_SESSION['userSession'] = $cUser;
+			if (isset($_GET['url'])) {
+				$url = $_GET['url'];
+				//echo ("<SCRIPT LANGUAGE='JavaScript'>document.location.href='$url';</SCRIPT>"); //FUNKTIONIERT NOCH NICHT!
+				echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>"); 
+			}else{
+				echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
+			}
 		}elseif(mysqli_num_rows($result) > 1){
 			echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='landing.php?m=cookie_error';</SCRIPT>");
 		}else{
 			//Besucht ein Nutzer, der eingeloggt bleibt, die Seite, wird $series behalten und $token geändert.
 			//So kann man mit einem gestohlenen Cookie sich nur so lange einloggen, bis der eigentliche Nutzer das tut (und den token ändert)
 			//Wird hier nun ein Cookie präsentiert, der zwar eine Entsprechung von series und user_id in der Datenbank hat, dessen token aber nicht übereinstimmt, so ist der Cookie wahrscheinlich gestohlen
-			$theft = mysqli_query($con, "SELECT * FROM remember_me WHERE series = '$cSeries' AND user_id = '$cUser'");
+			$theft = mysqli_query($con, "SELECT * FROM remember_me WHERE series = '$cSeries' AND user_id = '$cUser' AND token != '$cToken'");
 			if(mysqli_num_rows($theft) != 0){
 
 				$subject = "[VWI-Studienführer] Jemand hat versucht, sich in deinen Studienführer-Account einzuloggen";
@@ -108,9 +104,6 @@ if (isset($_SESSION['userSession'])!="") {
 }
 
 if (isset($_POST['btn-login'])) {
-	
-	
- 
 	$email = strip_tags($_POST['email']);
 	$password = strip_tags($_POST['password']);
 	 
@@ -190,8 +183,6 @@ if (isset($_POST['btn-login'])) {
 </div>
 <div class="signin-form">
 	<div class="container">
-		<button onclick="checkCookie()">Click me</button>
-		<button onclick="deleteCookie()">Delete</button>
 		<form class="form-signin" method="post" id="login-form">
 			<h3 class="form-signin-heading">Hier einloggen:</h3><hr />
 			
@@ -213,7 +204,7 @@ if (isset($_POST['btn-login'])) {
 			<div class="checkbox">
 				<label>
 					<input type="checkbox" name="rememberMe" id="rememberMe"> Eingeloggt bleiben
-					<a href="#" data-trigger="focus" data-toggle="popoverRememberMe" title="Um eingeloggt zu bleiben wird ein Cookie auf deiner Festplatte gespeichert." data-content="Nach 30 Tagen wird dieser Cookie ungültig und du musst dich erneut einloggen. Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du die Verwendung der nötigen Cookies. Cookies können jederzeit über deinen Browser gelöscht werden.">
+					<a href="#" data-trigger="focus" data-toggle="popoverRememberMe" title="Um eingeloggt zu bleiben wird ein Cookie auf deiner Festplatte gespeichert." data-content="Nach 30 Tagen wird dieser Cookie ungültig und du musst dich erneut einloggen. Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du die Verwendung der nötigen Cookies. Loggst du dich aus, werden die Cookies gelöscht. Cookies können außerdem jederzeit über deinen Browser gelöscht werden.">
 						<span class="glyphicon glyphicon-question-sign"></span>
 					</a>
 					<script>

--- a/login.php
+++ b/login.php
@@ -43,8 +43,52 @@ if (isset($_POST['btn-login'])) {
 				</div>";
 		}else{
 			$_SESSION['userSession'] = $row['user_ID'];
-			//header('Location: tree.php');
-			echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
+			//Set cookie if remember me checked
+			$check = $_POST['rememberMe'];
+			if($check == "on"){
+				$series = hash("sha256", (rand(0,1000)));
+				$token = hash("sha256", (rand(0,1000)));
+				?><script>setCookie("<?php echo $series ?>","<?php echo $token ?>",30);</script><?php
+			}
+			
+			//echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
+			
+			?><script>
+			function setCookie(svalue,tvalue,exdays) {
+				var d = new Date();
+				d.setTime(d.getTime() + (exdays*24*60*60*1000));
+				var expires = "expires=" + d.toGMTString();
+				document.cookie = "series" + "=" + svalue + ";" + "token" + "=" + tvalue + ";" + expires + ";path=/";
+			}
+
+			function getCookie(cname) {
+				var name = cname + "=";
+				var decodedCookie = decodeURIComponent(document.cookie);
+				var ca = decodedCookie.split(';');
+				for(var i = 0; i < ca.length; i++) {
+					var c = ca[i];
+					while (c.charAt(0) == ' ') {
+						c = c.substring(1);
+					}
+					if (c.indexOf(name) == 0) {
+						return c.substring(name.length, c.length);
+					}
+				}
+				return "";
+			}
+
+			function checkCookie() {
+				var user=getCookie("username");
+				if (user != "") {
+					alert("Welcome again " + user);
+				} else {
+				   user = prompt("Please enter your name:","");
+				   if (user != "" && user != null) {
+					   setCookie("username", user, 30);
+				   }
+				}
+			}
+			</script><?php
 		}
 	}else{
 		$msg = "<div class='alert alert-danger'>
@@ -82,6 +126,26 @@ if (isset($_POST['btn-login'])) {
 			
 			<div class="form-group">
 			<input type="password" class="form-control" placeholder="Passwort" name="password" required />
+			</div>
+			
+			<div class="checkbox">
+				<label>
+					<input type="checkbox" name="rememberMe" id="rememberMe"> Eingeloggt bleiben
+					<a href="#" data-trigger="focus" data-toggle="popoverRememberMe" title="Hierzu wird ein Cookie auf deiner Festplatte gespeichert." data-content="Falls du dich innerhalb von 30 Tagen nicht wieder einloggst, wird dieser Cookie ungültig und du musst dich erneut einloggen. Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du unsere Verwendung von Cookies.">
+						<span class="glyphicon glyphicon-question-sign"></span>
+					</a>
+					<script>
+					$(document).ready(function () {
+						$('[data-toggle="popoverRememberMe"]').popover();
+						
+						$('#rememberMe').change(function() {
+							if ($(this).prop('checked')) {
+								alert("Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du unsere Verwendung von Cookies."); //checked
+							}
+						});
+					});
+					</script>
+				</label>
 			</div>
 			
 			<a href="#" id="openPWRModal">Passwort vergessen?</a>

--- a/login.php
+++ b/login.php
@@ -7,14 +7,109 @@ include "header.php";
 <?php
 session_start();
 require_once 'connect.php';
+?>
 
+<script>
+function deleteCookie(){
+	document.cookie = "vwistudi_series=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+}
+
+function setCookie(svalue,tvalue,uvalue,exdays) {
+	var d = new Date();
+	d.setTime(d.getTime() + (exdays*24*60*60*1000));
+	var expires = "expires=" + d.toGMTString();
+	document.cookie = "vwistudi_series" + "=" + svalue + ";" + expires + ";path=/";
+	document.cookie = "vwistudi_token" + "=" + tvalue + ";" + expires + ";path=/";
+	document.cookie = "vwistudi_user" + "=" + uvalue + ";" + expires + ";path=/";
+	
+	//In Datenbank schreiben
+	$.ajax({
+		url: "setCookieInDB.php",
+		type: "post",
+		data: {series: svalue, token: tvalue, user_id: uvalue} ,
+		success: function (data) {
+			alert(data);
+		},
+		error: function() {
+			alert("error");
+		}
+	});
+}
+
+function getCookie(cname) {
+    var name = cname + "=";
+    var decodedCookie = decodeURIComponent(document.cookie);
+    var ca = decodedCookie.split(';');
+    for(var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}
+
+function checkCookie() {
+    var series=getCookie("vwistudi_series");
+	var token=getCookie("vwistudi_token");
+    if (series != "") {
+        alert("Saved series is: " + series + "Saved token is: " + token);
+    } else {
+       alert ("no cookie");
+    }
+}
+</script>
+
+<?php
 if (isset($_SESSION['userSession'])!="") {
 	//header('Location: tree.php');
 	echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
 	exit;
+}else{
+	if(isset($_COOKIE["vwistudi_series"]) && isset($_COOKIE["vwistudi_token"]) && isset($_COOKIE["vwistudi_user"])){
+		$cSeries = $_COOKIE["vwistudi_series"];
+		$cToken = $_COOKIE["vwistudi_token"];
+		$cUser = $_COOKIE["vwistudi_user"];
+		
+		$result = mysqli_query($con, "SELECT * FROM remember_me WHERE series = '$cSeries' AND token = '$cToken' AND user_id = '$cUser'");
+		if(mysqli_num_rows($result) == 1){
+			echo "LOGIN!";
+		}elseif(mysqli_num_rows($result) > 1){
+			echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='landing.php?m=cookie_error';</SCRIPT>");
+		}else{
+			//Besucht ein Nutzer, der eingeloggt bleibt, die Seite, wird $series behalten und $token geändert.
+			//So kann man mit einem gestohlenen Cookie sich nur so lange einloggen, bis der eigentliche Nutzer das tut (und den token ändert)
+			//Wird hier nun ein Cookie präsentiert, der zwar eine Entsprechung von series und user_id in der Datenbank hat, dessen token aber nicht übereinstimmt, so ist der Cookie wahrscheinlich gestohlen
+			$theft = mysqli_query($con, "SELECT * FROM remember_me WHERE series = '$cSeries' AND user_id = '$cUser'");
+			if(mysqli_num_rows($theft) != 0){
+
+				$subject = "[VWI-Studienführer] Jemand hat versucht, sich in deinen Studienführer-Account einzuloggen";
+				
+				if(mysqli_query($con, "DELETE FROM remember_me WHERE user_id = '$cUser'")){
+					$body = "jemand hat versucht, sich mit einem von dir gestohlenen Cookie in deinen Studienführer-Account einzuloggen. Wir haben sicherheithalber alle deine Auto-Login-Daten gelöscht, sodass du dich bei deinem nächsten wieder einloggen musst.";
+					$landing = "<SCRIPT LANGUAGE='JavaScript'>window.location.href='landing.php?m=cookie_theft';</SCRIPT>";
+				}else{
+					$body = "jemand hat versucht, sich mit einem von dir gestohlenen Cookie in deinen Studienführer-Account einzuloggen. Leider ist beim Löschen deiner Auto-Login-Daten ein Fehler aufgetreten. Lösche deine Cookies über das Browser-Menü und melde dich erneut mit der Eingeloggt-bleiben-Funktion beim Studienführer an, um deine Daten zu überschreiben. Falls du Fragen hast, wende dich direkt an die VWI-ESTIEM Hochschulgruppe.";	
+					$landing = "<SCRIPT LANGUAGE='JavaScript'>window.location.href='landing.php?m=cookie_theft_error';</SCRIPT>";
+				}
+				
+				$result1 = mysqli_query($con, "SELECT email FROM users WHERE user_ID = '$cUser'");
+				$row1 = mysqli_fetch_assoc($result1);
+				
+				EmailService::getService()->sendEmail($row1['email'], $row1['username'], $subject, $body);
+				
+				echo $landing;
+			}
+		}
+	}
 }
 
 if (isset($_POST['btn-login'])) {
+	
+	
  
 	$email = strip_tags($_POST['email']);
 	$password = strip_tags($_POST['password']);
@@ -43,52 +138,35 @@ if (isset($_POST['btn-login'])) {
 				</div>";
 		}else{
 			$_SESSION['userSession'] = $row['user_ID'];
+			
 			//Set cookie if remember me checked
-			$check = $_POST['rememberMe'];
-			if($check == "on"){
+			echo "elseschleife<br>";
+			if(isset($_POST['rememberMe'])){
+				echo "checkbox on";
 				$series = hash("sha256", (rand(0,1000)));
 				$token = hash("sha256", (rand(0,1000)));
-				?><script>setCookie("<?php echo $series ?>","<?php echo $token ?>",30);</script><?php
+				
+				?>
+				<!--Infos unsichtbar speichern, um sie so JS übergeben zu können-->
+				<span id="series" style="display:none"><?php echo $series ?></span>
+				<span id="token" style="display:none"><?php echo $token ?></span>
+				<span id="user-id" style="display:none"><?php echo $row['user_ID'] ?></span>
+
+				<script>
+				var s = $('#series').text();
+				var t = $('#token').text();
+				var u = $('#user-id').text();
+				
+				setCookie(s,t,u,30);
+				</script>
+				
+				<?php
 			}
 			
 			//echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='tree.php';</SCRIPT>");
 			
-			?><script>
-			function setCookie(svalue,tvalue,exdays) {
-				var d = new Date();
-				d.setTime(d.getTime() + (exdays*24*60*60*1000));
-				var expires = "expires=" + d.toGMTString();
-				document.cookie = "series" + "=" + svalue + ";" + "token" + "=" + tvalue + ";" + expires + ";path=/";
-			}
-
-			function getCookie(cname) {
-				var name = cname + "=";
-				var decodedCookie = decodeURIComponent(document.cookie);
-				var ca = decodedCookie.split(';');
-				for(var i = 0; i < ca.length; i++) {
-					var c = ca[i];
-					while (c.charAt(0) == ' ') {
-						c = c.substring(1);
-					}
-					if (c.indexOf(name) == 0) {
-						return c.substring(name.length, c.length);
-					}
-				}
-				return "";
-			}
-
-			function checkCookie() {
-				var user=getCookie("username");
-				if (user != "") {
-					alert("Welcome again " + user);
-				} else {
-				   user = prompt("Please enter your name:","");
-				   if (user != "" && user != null) {
-					   setCookie("username", user, 30);
-				   }
-				}
-			}
-			</script><?php
+			?>
+			<?php
 		}
 	}else{
 		$msg = "<div class='alert alert-danger'>
@@ -101,6 +179,8 @@ if (isset($_POST['btn-login'])) {
 
 }
 ?>
+
+
 <body>
 <div class="container">
 	<h1>Willkommen zum Studienführer!</h1>
@@ -110,6 +190,8 @@ if (isset($_POST['btn-login'])) {
 </div>
 <div class="signin-form">
 	<div class="container">
+		<button onclick="checkCookie()">Click me</button>
+		<button onclick="deleteCookie()">Delete</button>
 		<form class="form-signin" method="post" id="login-form">
 			<h3 class="form-signin-heading">Hier einloggen:</h3><hr />
 			
@@ -131,18 +213,21 @@ if (isset($_POST['btn-login'])) {
 			<div class="checkbox">
 				<label>
 					<input type="checkbox" name="rememberMe" id="rememberMe"> Eingeloggt bleiben
-					<a href="#" data-trigger="focus" data-toggle="popoverRememberMe" title="Hierzu wird ein Cookie auf deiner Festplatte gespeichert." data-content="Falls du dich innerhalb von 30 Tagen nicht wieder einloggst, wird dieser Cookie ungültig und du musst dich erneut einloggen. Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du unsere Verwendung von Cookies.">
+					<a href="#" data-trigger="focus" data-toggle="popoverRememberMe" title="Um eingeloggt zu bleiben wird ein Cookie auf deiner Festplatte gespeichert." data-content="Nach 30 Tagen wird dieser Cookie ungültig und du musst dich erneut einloggen. Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du die Verwendung der nötigen Cookies. Cookies können jederzeit über deinen Browser gelöscht werden.">
 						<span class="glyphicon glyphicon-question-sign"></span>
 					</a>
 					<script>
 					$(document).ready(function () {
 						$('[data-toggle="popoverRememberMe"]').popover();
 						
+						//Funktion, die ein Alert auslöst, wenn checkbox gewählt wird
+						/*
 						$('#rememberMe').change(function() {
 							if ($(this).prop('checked')) {
 								alert("Mit der Auswahl dieser Checkbox und damit der Nutzung dieser Funktion akzeptierst du unsere Verwendung von Cookies."); //checked
 							}
 						});
+						*/
 					});
 					</script>
 				</label>

--- a/logout.php
+++ b/logout.php
@@ -1,17 +1,36 @@
 <?php
 
+include "sessionsStart.php";
+
+include "header.php";
+
+include "connect.php";
+
+?>
+
+<?php
+
 session_start();
 
-if (!isset($_SESSION['userSession'])) {
- header("Location: login.php");
-} else if (isset($_SESSION['userSession'])!="") {
- header("Location: login.php");
+if(!isset($_SESSION['userSession'])){
+	header("Location: login.php");
+}elseif(isset($_SESSION['userSession'])!=""){
+	header("Location: login.php");
 }
 
-//if (isset($_GET['logout'])) {
- session_destroy();
- unset($_SESSION['userSession']);
- header("Location: login.php");
-//}
+session_destroy();
+unset($_SESSION['userSession']);
+
+//Cookies löschen
+unset($_COOKIE['vwistudi_series']);
+setcookie('vwistudi_series', '', time() - 3600, '/');
+unset($_COOKIE['vwistudi_token']);
+setcookie('vwistudi_token', '', time() - 3600, '/');
+unset($_COOKIE['vwistudi_user']);
+setcookie('vwistudi_user', '', time() - 3600, '/');
+//Cookie-Daten aus DB löschen
+mysqli_query($con, "DELETE FROM remember_me WHERE user_id = ".$userRow['user_ID']."");
+
+header("Location: login.php");
 
 ?>

--- a/sessionsStart.php
+++ b/sessionsStart.php
@@ -4,13 +4,9 @@ session_start();
 include 'connect.php';
 
 if (!isset($_SESSION['userSession'])) {
-	header("Location: login.php"); //to do: Landing mit Message, dann Login
+	$url = "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+	echo ("<SCRIPT LANGUAGE='JavaScript'>window.location.href='login.php?url=$url';</SCRIPT>");
 }
-/*
-$result = mysqli_query($con, "SELECT * FROM users WHERE user_ID=".$_SESSION['userSession']);
-$userRow = mysqli_fetch_assoc($result);
-$con->close();
-*/
 
 $query = $con->query("SELECT * FROM users WHERE user_ID=".$_SESSION['userSession']);
 $userRow=$query->fetch_array();

--- a/sessionsStart.php
+++ b/sessionsStart.php
@@ -4,7 +4,7 @@ session_start();
 include 'connect.php';
 
 if (!isset($_SESSION['userSession'])) {
- header("Location: login.php"); //to do: Landing mit Message, dann Login
+	header("Location: login.php"); //to do: Landing mit Message, dann Login
 }
 /*
 $result = mysqli_query($con, "SELECT * FROM users WHERE user_ID=".$_SESSION['userSession']);

--- a/setCookieInDB.php
+++ b/setCookieInDB.php
@@ -1,0 +1,25 @@
+<?php
+
+include "connect.php";
+
+?>
+
+<?php
+
+$series = $_POST['series'];
+$token = $_POST['token'];
+$user_id = $_POST['user_id'];
+
+$sql = "
+	INSERT INTO remember_me(user_id, series, token)
+	VALUES('$user_id', '$series', '$token')
+";
+
+
+if(mysqli_query($con, $sql)){
+	echo "erfolg";
+}
+
+
+
+?>


### PR DESCRIPTION
Durch die Checkbox bleibt man eingeloggt (30 Tage oder bis man sich ausloggt).

Theoretisch sind auch ein paar Sicherheitsdinger implementiert, die ich allerdings noch nicht testen konnte. Versucht sich bspw. jemand mit einem gestohlenen Cookie anzumelden, nachdem sich der ursprüngliche Besitzer schon wieder angemeldet hat, bekommt dieser eine Warnmail und der andere wird rausgeschmissen. Werde es mal auf den Server ziehen und testen; hat aber eben nicht so geklappt.

Ruft einer mit Cookie eine Studienführerseite auf, wird er (letztlich) zu tree.php umgeleitet. Eigentlich hätte ich es aber gerne, dass er direkt zur eigentlich Seite kommt. Ich hab das auch fast hinbekommen, aber irgendwie funktioniert das mit der gespeicherten URL nicht (siehe Zeile 70 in login.php). Auch eher nicht so elegant finde ich, dass die url des Ziels als Variable in der URL übergeben wird. Hat aber sonst nix geklappt...